### PR TITLE
Removed the animate height change property because it was causing the delete button to get stuck.

### DIFF
--- a/class/HPGrowingTextView.h
+++ b/class/HPGrowingTextView.h
@@ -78,7 +78,6 @@
 //real class properties
 @property int maxNumberOfLines;
 @property int minNumberOfLines;
-@property BOOL animateHeightChange;
 @property (retain) UITextView *internalTextView;	
 
 

--- a/class/HPGrowingTextView.m
+++ b/class/HPGrowingTextView.m
@@ -39,7 +39,6 @@
 @synthesize selectedRange;
 @synthesize editable;
 @synthesize dataDetectorTypes; 
-@synthesize animateHeightChange;
 @synthesize returnKeyType;
 
 
@@ -61,9 +60,7 @@
 		UIView *internal = (UIView*)[[internalTextView subviews] objectAtIndex:0];
 		minHeight = internal.frame.size.height;
 		minNumberOfLines = 1;
-		
-		animateHeightChange = YES;
-		
+
 		internalTextView.text = @"";
 		
 		[self setMaxNumberOfLines:3];
@@ -194,13 +191,6 @@
         
 		if (newSizeH <= maxHeight)
 		{
-			if(animateHeightChange){
-				[UIView beginAnimations:@"" context:nil];
-                [UIView setAnimationDuration:0.1f];
-				[UIView setAnimationDelegate:self];
-				[UIView setAnimationDidStopSelector:@selector(growDidStop)];
-				[UIView setAnimationBeginsFromCurrentState:YES];
-			}
 			
 			if ([delegate respondsToSelector:@selector(growingTextView:willChangeHeight:)]) {
 				[delegate growingTextView:self willChangeHeight:newSizeH];
@@ -221,9 +211,7 @@
             // [fixed] The growingTextView:didChangeHeight: delegate method was not called at all when not animating height changes.
             // thanks to Gwynne <http://blog.darkrainfall.org/>
             
-			if(animateHeightChange){
-				[UIView commitAnimations];
-			} else if ([delegate respondsToSelector:@selector(growingTextView:didChangeHeight:)]) {
+			if ([delegate respondsToSelector:@selector(growingTextView:didChangeHeight:)]) {
                 [delegate growingTextView:self didChangeHeight:newSizeH];
             }		
 		}


### PR DESCRIPTION
Removing option to animate height change because it can cause a bug where the delete key gets stuck if you are pressing delete during a height change.

NOTE: I submitted a bug with apple because at the lower level it appears to be a timing issue (I managed to track it down to a timer firing in UITextView) but the animation is interfering with it and causing the delete to get stuck. I recommend removing this property until apple can fix the bug on their end.  It was difficult to reproduce.  You have to have a string that wraps to the next line and there needs to be a space before the last character and the caps lock key must be off to reproduce the issue. Our QA team found that using the string "A. A. A. A. A. A. A. A. A. A. A. A. A. A. " and hitting the delete key 5 times quickly would reproduce it most of the time. 
