### PR TITLE
Allow custom view height and properly calculate height in sizeToFit

### DIFF
--- a/class/HPGrowingTextView.h
+++ b/class/HPGrowingTextView.h
@@ -52,8 +52,8 @@
 @interface HPGrowingTextView : UIView <UITextViewDelegate> {
 	HPTextViewInternal *internalTextView;	
 	
-	int minHeight;
-	int maxHeight;
+	CGFloat minHeight;
+	CGFloat maxHeight;
 	
 	//class properties
 	int maxNumberOfLines;
@@ -84,6 +84,8 @@
 
 //uitextview properties
 @property(assign) NSObject<HPGrowingTextViewDelegate> *delegate;
+@property(nonatomic,assign) CGFloat minHeight;
+@property(nonatomic,assign) CGFloat maxHeight;
 @property(nonatomic,assign) NSString *text;
 @property(nonatomic,assign) UIFont *font;
 @property(nonatomic,assign) UIColor *textColor;


### PR DESCRIPTION
- changed types of `minHeight` and `maxHeight` to `CGFloat` to maintain type compatibility with `CGSize`
- allow setting `minHeight` and `maxHeight` to custom values
- `sizeToFit` now readjusts frame height if necessary
- fixed issue where delegate method `growingTextView:willChangeHeight:` gets called on text change, even if height did not change.
