### PR TITLE
Fix default property attribute warning on internalTextView

### DIFF
--- a/class/HPGrowingTextView.h
+++ b/class/HPGrowingTextView.h
@@ -76,7 +76,7 @@
 @property int maxNumberOfLines;
 @property int minNumberOfLines;
 @property BOOL animateHeightChange;
-@property  UITextView *internalTextView;	
+@property (nonatomic, strong) UITextView *internalTextView;	
 
 
 //uitextview properties


### PR DESCRIPTION
Xcode 4.3 complains that "Default property attribute 'assign' not
appropriate for non-gc object"
