### PR TITLE
Placeholder string

### DIFF
--- a/class/HPGrowingTextView.h
+++ b/class/HPGrowingTextView.h
@@ -76,6 +76,8 @@
 @property int maxNumberOfLines;
 @property int minNumberOfLines;
 @property BOOL animateHeightChange;
+@property (nonatomic, strong) NSString *placeholder;
+@property (nonatomic, strong) UIColor *placeholderColor;
 @property (nonatomic, strong) UITextView *internalTextView;	
 
 

--- a/class/HPGrowingTextView.m
+++ b/class/HPGrowingTextView.m
@@ -46,6 +46,8 @@
 @synthesize dataDetectorTypes; 
 @synthesize animateHeightChange;
 @synthesize returnKeyType;
+@dynamic placeholder;
+@dynamic placeholderColor;
 
 // having initwithcoder allows us to use HPGrowingTextView in a Nib. -- aob, 9/2011
 - (id)initWithCoder:(NSCoder *)aDecoder
@@ -86,6 +88,9 @@
     internalTextView.text = @"";
     
     [self setMaxNumberOfLines:3];
+
+    [self setPlaceholderColor:[UIColor lightGrayColor]];
+    internalTextView.displayPlaceHolder = YES;
 }
 
 -(CGSize)sizeThatFits:(CGSize)size
@@ -186,6 +191,25 @@
     return minNumberOfLines;
 }
 
+- (NSString *)placeholder
+{
+    return internalTextView.placeholder;
+}
+
+- (void)setPlaceholder:(NSString *)placeholder
+{
+    [internalTextView setPlaceholder:placeholder];
+}
+
+- (UIColor *)placeholderColor
+{
+    return internalTextView.placeholderColor;
+}
+
+- (void)setPlaceholderColor:(UIColor *)placeholderColor 
+{
+    [internalTextView setPlaceholderColor:placeholderColor];
+}
 
 - (void)textViewDidChange:(UITextView *)textView
 {	
@@ -260,8 +284,18 @@
 		
 	}
 	
+    // Display (or not) the placeholder string
+    
+    BOOL wasDisplayingPlaceholder = internalTextView.displayPlaceHolder;
+    internalTextView.displayPlaceHolder = self.internalTextView.text.length == 0;
 	
-	if ([delegate respondsToSelector:@selector(growingTextViewDidChange:)]) {
+    if (wasDisplayingPlaceholder != internalTextView.displayPlaceHolder) {
+        [internalTextView setNeedsDisplay];
+    }
+    
+    // Tell the delegate that the text view changed
+	
+    if ([delegate respondsToSelector:@selector(growingTextViewDidChange:)]) {
 		[delegate growingTextViewDidChange:self];
 	}
 	

--- a/class/HPTextViewInternal.h
+++ b/class/HPTextViewInternal.h
@@ -28,7 +28,10 @@
 #import <UIKit/UIKit.h>
 
 
-@interface HPTextViewInternal : UITextView {
-}
+@interface HPTextViewInternal : UITextView
+
+@property (nonatomic, strong) NSString *placeholder;
+@property (nonatomic, strong) UIColor *placeholderColor;
+@property (nonatomic) BOOL displayPlaceHolder;
 
 @end

--- a/class/HPTextViewInternal.m
+++ b/class/HPTextViewInternal.m
@@ -30,6 +30,10 @@
 
 @implementation HPTextViewInternal
 
+@synthesize placeholder;
+@synthesize placeholderColor;
+@synthesize displayPlaceHolder;
+
 -(void)setText:(NSString *)text
 {
     BOOL originalValue = self.scrollEnabled;
@@ -89,7 +93,13 @@
     [super setContentSize:contentSize];
 }
 
-
-
+- (void)drawRect:(CGRect)rect
+{
+    [super drawRect:rect];
+    if (displayPlaceHolder && placeholder && placeholderColor) {
+        [placeholderColor set];
+        [placeholder drawInRect:CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f) withFont:self.font];
+    }
+}
 
 @end


### PR DESCRIPTION
Hi,

I've made a small modification to allow the user to specify a placeholder string as you'd find in a UITextField. Normally one would sub lass UITextView to do this, but this isn't possible with HPGrowingTextView since HPGrowingTextView isn't itself a subclass of UITextView.

The best solution in this case is to made the appropriate changes to the internal text view subclass and handle the display logic in HPGrowingTextView itself.
