### PR TITLE
ignore maxHeight if it is zero.

### DIFF
--- a/class/HPGrowingTextView.m
+++ b/class/HPGrowingTextView.m
@@ -239,9 +239,13 @@
 {
 	//size of content, so we can set the frame of self
 	NSInteger newSizeH = [self measureHeight];
-	if(newSizeH < minHeight || !internalTextView.hasText) newSizeH = minHeight; //not smalles than minHeight
-  if (internalTextView.frame.size.height > maxHeight) newSizeH = maxHeight; // not taller than maxHeight
-
+	if (newSizeH < minHeight || !internalTextView.hasText) {
+        newSizeH = minHeight; //not smalles than minHeight
+    }
+    else if (maxHeight && internalTextView.frame.size.height > maxHeight) {
+        newSizeH = maxHeight; // not taller than maxHeight
+    }
+    
 	if (internalTextView.frame.size.height != newSizeH)
 	{
         // [fixed] Pasting too much text into the view failed to fire the height change, 


### PR DESCRIPTION
Forgive me if I'm wrong, but testing the textview on ios7, a textview with zero maxHeight automatically resizes to zero height as soon as you type anything, since maxHeight zero was not being ignored correctly.
