### PR TITLE
fix distorted placeholder by setting contentMode to 'redraw'

### DIFF
--- a/class/HPGrowingTextView.m
+++ b/class/HPGrowingTextView.m
@@ -99,6 +99,7 @@
     internalTextView.contentInset = UIEdgeInsetsZero;		
     internalTextView.showsHorizontalScrollIndicator = NO;
     internalTextView.text = @"-";
+    internalTextView.contentMode = UIViewContentModeRedraw;
     [self addSubview:internalTextView];
     
     minHeight = internalTextView.frame.size.height;


### PR DESCRIPTION
After changing the device orientation to landscape the placeholder text is distorted:

![screen shot 2013-11-26 at 18 37 40](https://f.cloud.github.com/assets/137545/1624409/831335a0-56c1-11e3-86ee-3a8aeb7b843b.png)

![screen shot 2013-11-26 at 18 29 53](https://f.cloud.github.com/assets/137545/1624384/08c30fc8-56c1-11e3-9bde-716f5feb868a.png)

That is because the default content mode is 'scale to fill'. Setting the content mode to 'redraw' helps.
