### PR TITLE
TextView should not resignFirstResponder automatically in shouldChangeTextInRange

### DIFF
--- a/class/HPGrowingTextView.m
+++ b/class/HPGrowingTextView.m
@@ -643,7 +643,6 @@
 			if (![delegate performSelector:@selector(growingTextViewShouldReturn:) withObject:self]) {
 				return YES;
 			} else {
-				[textView resignFirstResponder];
 				return NO;
 			}
 		}


### PR DESCRIPTION
Hello HansPinckaers:

Firstly, thank you to wrote the GrowingTextView for everyone. 

I make a little changes,  I think TextView should not resignFirstResponder automatically in shouldChangeTextInRange，some times we want to stop input when detected \n’, but don’t want to dismiss keyboard.  if need to dismiss keyboard,  the best way is add resignFirstResponder in the delegate’s callback function.  What do you think?

Best Wishes!

Lings He
