### PR TITLE
handle korean keyboard properly

### DIFF
--- a/class/HPGrowingTextView.h
+++ b/class/HPGrowingTextView.h
@@ -67,6 +67,7 @@
 	
 	BOOL animateHeightChange;
     NSTimeInterval animationDuration;
+    BOOL willRefreshHeight;
 	
 	//uitextview properties
 	NSObject <HPGrowingTextViewDelegate> *__unsafe_unretained delegate;


### PR DESCRIPTION
if we use korean keyboard, UITextView occasionally fires 2 textViewDidChange events simultaneously.
for example, there is "버그버그ㅂ". we presse the "ㅓ" key. then text is changed to "버그버그버"
but UITextView fires 2 textViewDidChange events. The first event is "버그버그ㅂ" to "버그버그". The second event is "버그버그" to "버그버그버".
so we should use the last event of these events.

current version capture
https://www.dropbox.com/s/j7jswke288ye6o5/GrowingTextView-Korean-Bug.mov

fixed version capture
https://www.dropbox.com/s/2ehazrxkgbotq1h/GrowingTextView-Korean-Bug-Fixed.mov
