### PR TITLE
Small fix for erratic scroll offset correction on iOS 7

### DIFF
--- a/class/HPGrowingTextView.m
+++ b/class/HPGrowingTextView.m
@@ -362,8 +362,13 @@
 {
     CGRect r = [internalTextView caretRectForPosition:internalTextView.selectedTextRange.end];
     CGFloat caretY =  MAX(r.origin.y - internalTextView.frame.size.height + r.size.height + 8, 0);
-    if (internalTextView.contentOffset.y < caretY && r.origin.y != INFINITY)
+    if (internalTextView.contentOffset.y < caretY && r.origin.y != INFINITY) {
         internalTextView.contentOffset = CGPointMake(0, caretY);
+        
+        BOOL scrollEnabled = internalTextView.scrollEnabled;
+        internalTextView.scrollEnabled = !scrollEnabled;
+        internalTextView.scrollEnabled = scrollEnabled;
+    }
 }
 
 -(void)resizeTextView:(NSInteger)newSizeH


### PR DESCRIPTION
Suggested here: http://stackoverflow.com/a/20989956/1045904 and it works well

In my case, just when the growing textview was growing to 3 lines (its maxLines), the first scroll offset correction wouldn't work, at least until another character was typed. 
