### PR TITLE
Deprecation warning for deployment target set to iOS 7

### DIFF
--- a/class/HPTextViewInternal.m
+++ b/class/HPTextViewInternal.m
@@ -111,7 +111,10 @@
         }
         else {
             [self.placeholderColor set];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [self.placeholder drawInRect:CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f) withFont:self.font];
+#pragma clang diagnostic pop
         }
     }
 }

--- a/example/GrowingTextViewExample.xcodeproj/project.pbxproj
+++ b/example/GrowingTextViewExample.xcodeproj/project.pbxproj
@@ -176,7 +176,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "GrowingTextViewExample" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -245,7 +245,7 @@
 				GCC_PREFIX_HEADER = GrowingTextViewExample_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "GrowingTextViewExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = GrowingTextViewExample;
 				SDKROOT = iphoneos;
 			};
@@ -261,7 +261,7 @@
 				GCC_PREFIX_HEADER = GrowingTextViewExample_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "GrowingTextViewExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = GrowingTextViewExample;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -271,11 +271,11 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -283,7 +283,6 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/example/GrowingTextViewExample.xcodeproj/project.pbxproj
+++ b/example/GrowingTextViewExample.xcodeproj/project.pbxproj
@@ -245,7 +245,7 @@
 				GCC_PREFIX_HEADER = GrowingTextViewExample_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "GrowingTextViewExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PRODUCT_NAME = GrowingTextViewExample;
 				SDKROOT = iphoneos;
 			};
@@ -261,7 +261,7 @@
 				GCC_PREFIX_HEADER = GrowingTextViewExample_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "GrowingTextViewExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PRODUCT_NAME = GrowingTextViewExample;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
Building `GrowingTextView` with Xcode 5 will issue a deprecation warning for `drawInRect:withFont:` when setting the deployment target of the project to iOS 7.0. I assume that you still want to support iOS <7, so instead of rewriting the code, I disabled the warning.

Also, I updated the example project to the settings recommended by Xcode 5.

Please merge - thanks
