### PR TITLE
Update HPTextViewInternal.m

### DIFF
--- a/class/HPTextViewInternal.m
+++ b/class/HPTextViewInternal.m
@@ -111,7 +111,7 @@
         }
         else {
             [self.placeholderColor set];
-            [self.placeholder drawInRect:CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f) withFont:self.font];
+            [self.placeholder drawInRect:CGRectMake(8.0f, 8.0f, self.frame.size.width - 16.0f, self.frame.size.height - 16.0f) withAttributes:@{NSFontAttributeName: self.font}];
         }
     }
 }


### PR DESCRIPTION
drawInRect:withFont: is deprecated as of iOS7 (line 114)
drawInRect:withAttributes: should be used instead.
